### PR TITLE
add support for user defined version badge

### DIFF
--- a/lib/maven_central.rb
+++ b/lib/maven_central.rb
@@ -24,6 +24,21 @@ class MavenCentral
     end
   end
 
+     # Requests a specific version of the specified artifact.
+  def self.defined_artifact_version(group_id, artifact_id, version)
+    resp = get('/solrsearch/select', query: {
+      q: format_query_with_version(group_id, artifact_id, version), rows: 1
+    })
+    raise HTTParty::ResponseError.new(resp) if resp.code != 200
+
+    doc = resp.parsed_response['response']
+    if doc['numFound'] > 0
+      doc['docs'][0]['v']
+    else
+      raise NotFoundError
+    end
+  end
+
   # Returns URL of the web page with details about the specified artifact.
   def self.artifact_details_url(group_id, artifact_id, version)
     "#{base_uri}/#artifactdetails%7C#{group_id}%7C#{artifact_id}%7C#{version}%7C"
@@ -39,6 +54,10 @@ class MavenCentral
 
   def self.format_query(group_id, artifact_id)
     %{g:"#{group_id}" AND a:"#{artifact_id}"}
+  end
+
+  def self.format_query_with_version(group_id, artifact_id, version)
+    %{g:"#{group_id}" AND a:"#{artifact_id}" AND v:"#{version}"}
   end
 end
 

--- a/lib/web.rb
+++ b/lib/web.rb
@@ -22,9 +22,14 @@ get '/maven-central/:group/:artifact/badge.:format' do |group, artifact, format|
 
   content_type format
   subject = params['subject'] || DEFAULT_SUBJECT
+  version = params[:version]
 
   begin
-    version = MavenCentral.last_artifact_version(group, artifact)
+    if (defined?(version)).nil? # will now return true or false
+      version = MavenCentral.last_artifact_version(group, artifact)
+   else
+      version = MavenCentral.defined_artifact_version(group, artifact, version)
+    end
     color = :brightgreen
   rescue NotFoundError
     version = 'unknown'


### PR DESCRIPTION
Since many people seem to be needing this, including my self. This simple change adds support for defining a specific version for the badge, e.g GET `https://maven-badges.herokuapp.com//maven-central/groupId/artifact/badge.png?version=0.4` would return the badge for 0.4 version If the version is non existent then, the unknown badge is still returned. if there is no version specified then it will return the last version.